### PR TITLE
Update envoy_parser.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG UPSTREAM_VERSION=latest
+ARG UPSTREAM_VERSION=2.23.1
 FROM amazon/aws-for-fluent-bit:${UPSTREAM_VERSION}
 
 ADD conf/* /fluent-bit/conf/

--- a/parsers/envoy_parser.conf
+++ b/parsers/envoy_parser.conf
@@ -1,4 +1,4 @@
 [PARSER]
     Name envoy
     Format regex
-    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^ ]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"
+    Regex ^\[(?<start_time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)? (?<protocol>\S+)" (?<code>[^ ]*) (?<response_flags>[^ ]*) (?<bytes_received>[^ ]*) (?<bytes_sent>[^ ]*) (?<duration>[^ ]*) (?<x_envoy_upstream_service_time>[^ ]*) "(?<x_forwarded_for>[^\"]*)" "(?<user_agent>[^\"]*)" "(?<request_id>[^\"]*)" "(?<authority>[^ ]*)" "(?<upstream_host>[^ ]*)"


### PR DESCRIPTION
this regex failed for some requests due to a wrong pattern for `x_forwarded_for` which may contain spaces ` ` in case there are multiple hops such as `"79.248.170.134, 64.252.88.99, 127.0.0.1"`:

```
[2022-03-23T10:36:31.512Z] "GET /region/berlin/news/id_91883220/berlin-brandenburger-landwirten-fehlen-erntehelfer.html HTTP/1.1" 500 - 0 7810 223 223 "79.248.170.134, 64.252.88.99, 127.0.0.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36" "e47681c1-72e0-98c2-becb-6d82dd07872b" "paper.services.vpc.internal" "127.0.0.1:3000"
```